### PR TITLE
Add PackedIpRange to minimise memory storage.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,16 @@
             <artifactId>hamcrest-library</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.pholser</groupId>
+            <artifactId>junit-quickcheck-core</artifactId>
+            <version>0.7</version>
+        </dependency>
+        <dependency>
+            <groupId>com.pholser</groupId>
+            <artifactId>junit-quickcheck-generators</artifactId>
+            <version>0.7</version>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>
@@ -64,7 +74,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.10</version>
+                <version>4.12</version>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>

--- a/src/main/java/net/ripe/ipresource/PackedIpRange.java
+++ b/src/main/java/net/ripe/ipresource/PackedIpRange.java
@@ -43,11 +43,11 @@ public class PackedIpRange {
 
     public PackedIpRange(IpRange ipRange) {
         if (ipRange.getType() == IPv4) {
-            int start = ipRange.getStart().getValue().intValue();
-            int end = ipRange.getEnd().getValue().intValue();
-            content = ByteBuffer.allocate(8)
-                    .putInt(start)
-                    .putInt(end).array();
+            long start = ipRange.getStart().getValue().longValue();
+            long end = ipRange.getEnd().getValue().longValue();
+            content = new byte[8];
+            toBytes(start, 0, content);
+            toBytes(end, 4, content);
         } else if (ipRange.getType() == IPv6) {
             byte[] start = ipRange.getStart().getValue().toByteArray();
             byte[] end = ipRange.getEnd().getValue().toByteArray();
@@ -71,10 +71,9 @@ public class PackedIpRange {
     public IpRange toIpRange() {
         if (content.length == 8) {
             // it's IPv4
-            ByteBuffer byteBuffer = ByteBuffer.wrap(content);
-            int start = byteBuffer.getInt(0);
-            int end = byteBuffer.getInt(4);
-            return IpRange.range(new Ipv4Address(start), new Ipv4Address(end));
+            long s = fromBytes(content, 0);
+            long e = fromBytes(content, 4);
+            return IpRange.range(new Ipv4Address(s), new Ipv4Address(e));
         } else {
             // it's IPv6
             final ByteBuffer byteBuffer = ByteBuffer.wrap(content);
@@ -91,5 +90,22 @@ public class PackedIpRange {
             final BigInteger end = new BigInteger(tmp);
             return IpRange.range(new Ipv6Address(start), new Ipv6Address(end));
         }
+    }
+
+    private static long fromBytes(byte[] b, int offset) {
+        long s = 0L;
+        for (short i = 0; i < 3; i++) {
+            s |= b[i + offset] & 0xFF;
+            s <<= 8;
+        }
+        s |= b[3 + offset] & 0xFF;
+        return s;
+    }
+
+    private static void toBytes(long s, int offset, byte[] b) {
+        b[offset] = (byte) (s >>> 24);
+        b[offset + 1] = (byte) (s >>> 16);
+        b[offset + 2] = (byte) (s >>> 8);
+        b[offset + 3] = (byte) s;
     }
 }

--- a/src/main/java/net/ripe/ipresource/PackedIpRange.java
+++ b/src/main/java/net/ripe/ipresource/PackedIpRange.java
@@ -1,0 +1,85 @@
+/**
+ * The BSD License
+ *
+ * Copyright (c) 2010-2012 RIPE NCC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the RIPE NCC nor the names of its contributors may be
+ *     used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.ripe.ipresource;
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+
+import static net.ripe.ipresource.IpResourceType.IPv4;
+import static net.ripe.ipresource.IpResourceType.IPv6;
+
+public class PackedIpRange {
+    private final byte[] content;
+
+    public PackedIpRange(IpRange ipRange) {
+        if (ipRange.getType() == IPv4) {
+            int start = ipRange.getStart().getValue().intValue();
+            int end = ipRange.getEnd().getValue().intValue();
+            content = ByteBuffer.allocate(8)
+                    .putInt(start)
+                    .putInt(end).array();
+        } else if (ipRange.getType() == IPv6) {
+            byte[] start = ipRange.getStart().getValue().toByteArray();
+            byte[] end = ipRange.getEnd().getValue().toByteArray();
+            content = ByteBuffer.allocate(34)
+                    .put((byte) start.length)
+                    .put(start)
+                    .put((byte) end.length)
+                    .put(end)
+                    .array();
+        } else {
+            throw new IllegalArgumentException("Asn is not supported here");
+        }
+    }
+
+    public IpRange toIpRange() {
+        if (content.length == 8) {
+            ByteBuffer byteBuffer = ByteBuffer.wrap(content);
+            int start = byteBuffer.getInt(0);
+            int end = byteBuffer.getInt(4);
+            return IpRange.range(new Ipv4Address(start), new Ipv4Address(end));
+        } else if (content.length == 34) {
+            final ByteBuffer byteBuffer = ByteBuffer.wrap(content);
+
+            final int sLen = byteBuffer.get();
+            byte[] tmp = new byte[sLen];
+            byteBuffer.get(tmp, 0, sLen);
+            final BigInteger start = new BigInteger(tmp);
+
+            final int eLen = byteBuffer.get();
+            tmp = new byte[eLen];
+            byteBuffer.get(tmp, 0, eLen);
+
+            final BigInteger end = new BigInteger(tmp);
+            return IpRange.range(new Ipv6Address(start), new Ipv6Address(end));
+        }
+        return null;
+    }
+}

--- a/src/test/java/net/ripe/ipresource/PackedIpRangeTest.java
+++ b/src/test/java/net/ripe/ipresource/PackedIpRangeTest.java
@@ -1,0 +1,68 @@
+/**
+ * The BSD License
+ *
+ * Copyright (c) 2010-2012 RIPE NCC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the RIPE NCC nor the names of its contributors may be
+ *     used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.ripe.ipresource;
+
+import com.pholser.junit.quickcheck.Property;
+import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import org.junit.runner.RunWith;
+
+import java.math.BigInteger;
+
+import static org.hamcrest.number.OrderingComparison.greaterThan;
+import static org.hamcrest.number.OrderingComparison.lessThan;
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeThat;
+
+@RunWith(JUnitQuickcheck.class)
+public class PackedIpRangeTest {
+
+    private static BigInteger maxIpv6 = BigInteger.valueOf(2L).pow(128).subtract(BigInteger.ONE);
+
+    @Property(trials = 1000)
+    public void packUnpackIpv4(int s, int e) throws Exception {
+        assumeThat(s, greaterThan(0));
+        assumeThat(e, greaterThan(s));
+        IpRange range = IpRange.range(new Ipv4Address(s), new Ipv4Address(e));
+        IpRange unpacked = new PackedIpRange(range).toIpRange();
+        assertEquals(range, unpacked);
+    }
+
+    @Property(trials = 1000)
+    public void packUnpackIpv6(BigInteger s, BigInteger e) throws Exception {
+        assumeThat(s, greaterThan(BigInteger.ZERO));
+        assumeThat(e, greaterThan(s));
+        assumeThat(s, lessThan(maxIpv6));
+        assumeThat(e, lessThan(maxIpv6));
+        IpRange range = IpRange.range(new Ipv6Address(s), new Ipv6Address(e));
+        IpRange unpacked = new PackedIpRange(range).toIpRange();
+        assertEquals(range, unpacked);
+    }
+
+}

--- a/src/test/java/net/ripe/ipresource/PackedIpRangeTest.java
+++ b/src/test/java/net/ripe/ipresource/PackedIpRangeTest.java
@@ -31,6 +31,7 @@ package net.ripe.ipresource;
 
 import com.pholser.junit.quickcheck.Property;
 import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.math.BigInteger;
@@ -50,8 +51,7 @@ public class PackedIpRangeTest {
         assumeThat(s, greaterThan(0));
         assumeThat(e, greaterThan(s));
         IpRange range = IpRange.range(new Ipv4Address(s), new Ipv4Address(e));
-        IpRange unpacked = new PackedIpRange(range).toIpRange();
-        assertEquals(range, unpacked);
+        assertSameRange(range);
     }
 
     @Property(trials = 1000)
@@ -61,8 +61,17 @@ public class PackedIpRangeTest {
         assumeThat(s, lessThan(maxIpv6));
         assumeThat(e, lessThan(maxIpv6));
         IpRange range = IpRange.range(new Ipv6Address(s), new Ipv6Address(e));
+        assertSameRange(range);
+    }
+
+    @Test
+    public void specialCases() {
+        assertSameRange(IpRange.parse("128.0.1.0/24"));
+        assertSameRange(IpRange.parse("1.0.0.0/8"));
+    }
+
+    private void assertSameRange(IpRange range) {
         IpRange unpacked = new PackedIpRange(range).toIpRange();
         assertEquals(range, unpacked);
     }
-
 }


### PR DESCRIPTION
Hi there!

We need to store prefixes in RPKI validator as compact as possible. So this is a PR to add the PackedIpRange class. Please note that I haven't checked how much memory is actually saved, but this is just the most compact representation I could quickly come up with.