### PR TITLE
Normalize retained resources

### DIFF
--- a/src/main/java/net/ripe/ipresource/IpResourceSet.java
+++ b/src/main/java/net/ripe/ipresource/IpResourceSet.java
@@ -198,7 +198,7 @@ public class IpResourceSet implements Iterable<IpResource>, Serializable {
         while (thisResource != null && thatResource != null) {
             IpResource intersect = thisResource.intersect(thatResource);
             if (intersect != null) {
-                temp.put(intersect.getEnd(), intersect);
+                temp.put(intersect.getEnd(), normalize(intersect));
             }
             int compareTo = thisResource.getEnd().compareTo(thatResource.getEnd());
             if (compareTo <= 0) {

--- a/src/test/java/net/ripe/ipresource/IpResourceSetTest.java
+++ b/src/test/java/net/ripe/ipresource/IpResourceSetTest.java
@@ -173,6 +173,14 @@ public class IpResourceSetTest {
     }
 
     @Test
+    public void shouldNormalizeRetainedResources() {
+        // Without normalization on retainAll the single IP resource was retained as the range AS64513-AS64513.
+        IpResourceSet subject = IpResourceSet.parse("AS64513");
+        subject.retainAll(IpResourceSet.ALL_PRIVATE_USE_RESOURCES);
+        assertEquals("AS64513", subject.toString());
+    }
+
+    @Test
     public void test_removal_of_multiple_overlapping_resources() {
         subject = IpResourceSet.parse("AS1-AS3, AS5-AS10, AS13-AS15");
         subject.remove(IpResource.parse("AS1-AS10"));


### PR DESCRIPTION
The `IpResourceSet#retainAll` method should normalize resources before adding to the internal tree. Otherwise a resource like `AS64513` was added as the singleton range `AS64513-AS64513`.