### PR TITLE
Add test scope on junit quicktest dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,11 +56,13 @@
             <groupId>com.pholser</groupId>
             <artifactId>junit-quickcheck-core</artifactId>
             <version>0.7</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.pholser</groupId>
             <artifactId>junit-quickcheck-generators</artifactId>
             <version>0.7</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Junit quicktest dependency did not have test scope, causing it to
be transitively pulled into other builds.