### PR TITLE
Fix the corner case of IPv4 mapped to IPv6: "::ffff:0.0.0.0/96".

### DIFF
--- a/src/main/java/net/ripe/ipresource/Ipv6Address.java
+++ b/src/main/java/net/ripe/ipresource/Ipv6Address.java
@@ -123,8 +123,14 @@ public class Ipv6Address extends IpAddress {
         String ipv6Section = StringUtils.substringBeforeLast(ipAddressString, ":");
         String ipv4Section = StringUtils.substringAfterLast(ipAddressString, ":");
         try {
-            String ipv4SectionInIpv6Notation = StringUtils.join(new Ipv6Address(Ipv4Address.parse(ipv4Section).getValue()).toString().split(":"), ":", 2, 4);
-            return ipv6Section + ":" + ipv4SectionInIpv6Notation;
+            final String v6 = new Ipv6Address(Ipv4Address.parse(ipv4Section).getValue()).toString();
+            final String[] split = v6.split(":");
+            if (split.length == 0) {
+                return ipv6Section;
+            } else {
+                String ipv4SectionInIpv6Notation = StringUtils.join(split, ":", 2, 4);
+                return ipv6Section + ":" + ipv4SectionInIpv6Notation;
+            }
         } catch(IllegalArgumentException e) {
             throw new IllegalArgumentException("Embedded Ipv4 in IPv6 address is invalid: " + ipAddressString, e);
         }

--- a/src/main/java/net/ripe/ipresource/Ipv6Address.java
+++ b/src/main/java/net/ripe/ipresource/Ipv6Address.java
@@ -123,16 +123,11 @@ public class Ipv6Address extends IpAddress {
         String ipv6Section = StringUtils.substringBeforeLast(ipAddressString, ":");
         String ipv4Section = StringUtils.substringAfterLast(ipAddressString, ":");
         try {
-            final String v6 = new Ipv6Address(Ipv4Address.parse(ipv4Section).getValue()).toString();
-            final String[] split = v6.split(":");
-            if (split.length == 0) {
-                // that means that IPv4 part has a special shortcut such as "0" and can be ignored
-                return ipv6Section;
-            } else {
-                String ipv4SectionInIpv6Notation = StringUtils.join(split, ":", 2, 4);
-                return ipv6Section + ":" + ipv4SectionInIpv6Notation;
-            }
-        } catch(IllegalArgumentException e) {
+            long ipv4value = Ipv4Address.parse(ipv4Section).longValue();
+            return ipv6Section + ":" +
+                Long.toString(ipv4value >>> 16, 16) + ":" +
+                Long.toString(ipv4value & 0xffff, 16);
+        } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("Embedded Ipv4 in IPv6 address is invalid: " + ipAddressString, e);
         }
     }

--- a/src/main/java/net/ripe/ipresource/Ipv6Address.java
+++ b/src/main/java/net/ripe/ipresource/Ipv6Address.java
@@ -126,6 +126,7 @@ public class Ipv6Address extends IpAddress {
             final String v6 = new Ipv6Address(Ipv4Address.parse(ipv4Section).getValue()).toString();
             final String[] split = v6.split(":");
             if (split.length == 0) {
+                // that means that IPv4 part has a special shortcut such as "0" and can be ignored
                 return ipv6Section;
             } else {
                 String ipv4SectionInIpv6Notation = StringUtils.join(split, ":", 2, 4);

--- a/src/test/java/net/ripe/ipresource/IpRangeTest.java
+++ b/src/test/java/net/ripe/ipresource/IpRangeTest.java
@@ -102,6 +102,16 @@ public class IpRangeTest {
         assertThat(prefixes, is(Arrays.asList(IpRange.parse("2001::/16"))));
     }
 
+    @Test
+    public void shouldIpv4ZerosInsideIpv6() {
+        assertEquals(IpRange.parse("::ffff:2da4:7c00/120"), IpRange.parse("::ffff:45.164.124.0/120"));
+    }
+
+    @Test
+    public void shouldParseIpv4ZerosInsideIpv6() {
+        assertEquals(IpRange.parse("::ffff:0:0/96"), IpRange.parse("::ffff:0.0.0.0/96"));
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void shouldRejectAsnRanges() {
         IpRange.parse("AS3333-AS4444");

--- a/src/test/java/net/ripe/ipresource/IpRangeTest.java
+++ b/src/test/java/net/ripe/ipresource/IpRangeTest.java
@@ -113,6 +113,11 @@ public class IpRangeTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
+    public void shouldNotParseInvalidIpv4InsideIpv6() {
+        assertNull(IpRange.parse("2001:123.456:DEAD:BEEF.123"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
     public void shouldRejectAsnRanges() {
         IpRange.parse("AS3333-AS4444");
     }


### PR DESCRIPTION
  * [ ] I have updated the changelog in README.md

It may be that I haven't fully fixed _all_ the corner cases. Please correct me if so.