### PR TITLE
Add an immutable version of the `IpResourceSet`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,13 @@ See: https://raw.github.com/RIPE-NCC/ipresource/master/LICENSE.txt
 Description
 -----------
 
-This library contains a representation of IP resources:
+This library contains a representation of IP number resources:
 
 * IPv4 addresses
 * IPv6 addresses
 * Autonomous System Numbers (AS numbers).
+* Ranges of the above (`AsnRange`, `IpRange` which both extend `IpResourceRange`)
+* Sets of number resources (`ImmutableResourceSet` and `IpResourceSet`)
+
+Finally, an optimised `IntervalMap` allows you to keep track of many number resources including support for querying
+the (closest) enclosing resources, more specifics, etc.

--- a/pom.xml
+++ b/pom.xml
@@ -113,8 +113,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
 

--- a/src/main/java/net/ripe/ipresource/ImmutableResourceSet.java
+++ b/src/main/java/net/ripe/ipresource/ImmutableResourceSet.java
@@ -61,13 +61,13 @@ public final class ImmutableResourceSet implements Iterable<IpResource>, Seriali
      *
      * resourcesByEndPoint.ceilingEntry(resourceToLookup.getStart())
      */
-    private final TreeMap<IpResource, IpResource> resourcesByEndPoint;
+    private final TreeMap<UniqueIpResource, IpResource> resourcesByEndPoint;
 
     private ImmutableResourceSet() {
         this.resourcesByEndPoint = new TreeMap<>();
     }
 
-    private ImmutableResourceSet(TreeMap<IpResource, IpResource> resourcesByEndPoint) {
+    private ImmutableResourceSet(TreeMap<UniqueIpResource, IpResource> resourcesByEndPoint) {
         this.resourcesByEndPoint = resourcesByEndPoint;
     }
 
@@ -77,7 +77,7 @@ public final class ImmutableResourceSet implements Iterable<IpResource>, Seriali
     }
 
     public static ImmutableResourceSet of(IpResource resource) {
-        TreeMap<IpResource, IpResource> resourcesByEndpoint = new TreeMap<>();
+        TreeMap<UniqueIpResource, IpResource> resourcesByEndpoint = new TreeMap<>();
         resourcesByEndpoint.put(resource.getEnd(), normalize(resource));
         return new ImmutableResourceSet(resourcesByEndpoint);
     }
@@ -145,7 +145,7 @@ public final class ImmutableResourceSet implements Iterable<IpResource>, Seriali
         } else if (that.isEmpty()) {
             return that;
         } else {
-            TreeMap<IpResource, IpResource> temp = new TreeMap<>();
+            TreeMap<UniqueIpResource, IpResource> temp = new TreeMap<>();
             Iterator<IpResource> thisIterator = this.iterator();
             Iterator<IpResource> thatIterator = that.iterator();
             IpResource thisResource = thisIterator.next();
@@ -198,7 +198,7 @@ public final class ImmutableResourceSet implements Iterable<IpResource>, Seriali
     }
 
     public boolean contains(IpResource resource) {
-        Entry<IpResource, IpResource> potentialMatch = resourcesByEndPoint.ceilingEntry(resource.getStart());
+        Entry<UniqueIpResource, IpResource> potentialMatch = resourcesByEndPoint.ceilingEntry(resource.getStart());
         return potentialMatch != null && potentialMatch.getValue().contains(resource);
     }
 
@@ -221,7 +221,7 @@ public final class ImmutableResourceSet implements Iterable<IpResource>, Seriali
     }
 
     public boolean intersects(IpResource resource) {
-        Entry<IpResource, IpResource> potentialMatch = resourcesByEndPoint.ceilingEntry(resource.getStart());
+        Entry<UniqueIpResource, IpResource> potentialMatch = resourcesByEndPoint.ceilingEntry(resource.getStart());
         return potentialMatch != null && potentialMatch.getValue().overlaps(resource);
     }
 
@@ -283,7 +283,7 @@ public final class ImmutableResourceSet implements Iterable<IpResource>, Seriali
     }
 
     public static class Builder {
-        private final TreeMap<IpResource, IpResource> resourcesByEndPoint;
+        private final TreeMap<UniqueIpResource, IpResource> resourcesByEndPoint;
 
         public Builder() {
             this.resourcesByEndPoint = new TreeMap<>();
@@ -341,7 +341,7 @@ public final class ImmutableResourceSet implements Iterable<IpResource>, Seriali
         }
 
         public Builder remove(IpResource resource) {
-            Entry<IpResource, IpResource> potentialMatch = resourcesByEndPoint.ceilingEntry(resource.getStart());
+            Entry<UniqueIpResource, IpResource> potentialMatch = resourcesByEndPoint.ceilingEntry(resource.getStart());
             while (potentialMatch != null && potentialMatch.getValue().overlaps(resource)) {
                 resourcesByEndPoint.remove(potentialMatch.getKey());
 

--- a/src/main/java/net/ripe/ipresource/ImmutableResourceSet.java
+++ b/src/main/java/net/ripe/ipresource/ImmutableResourceSet.java
@@ -44,9 +44,9 @@ import java.util.stream.StreamSupport;
  */
 public final class ImmutableResourceSet implements Iterable<IpResource>, Serializable {
 
-    public static final ImmutableResourceSet IP_PRIVATE_USE_RESOURCES = ImmutableResourceSet.of(IpResourceSet.IP_PRIVATE_USE_RESOURCES);
-    public static final ImmutableResourceSet ASN_PRIVATE_USE_RESOURCES = ImmutableResourceSet.of(IpResourceSet.ASN_PRIVATE_USE_RESOURCES);
-    public static final ImmutableResourceSet ALL_PRIVATE_USE_RESOURCES = ImmutableResourceSet.of(IpResourceSet.ALL_PRIVATE_USE_RESOURCES);
+    public static final ImmutableResourceSet IP_PRIVATE_USE_RESOURCES = ImmutableResourceSet.parse("10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,fc00::/7");
+    public static final ImmutableResourceSet ASN_PRIVATE_USE_RESOURCES = ImmutableResourceSet.parse("AS64512-AS65534");
+    public static final ImmutableResourceSet ALL_PRIVATE_USE_RESOURCES = ASN_PRIVATE_USE_RESOURCES.union(IP_PRIVATE_USE_RESOURCES);
 
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/net/ripe/ipresource/ImmutableResourceSet.java
+++ b/src/main/java/net/ripe/ipresource/ImmutableResourceSet.java
@@ -179,6 +179,7 @@ public final class ImmutableResourceSet implements Iterable<IpResource>, Seriali
         return universal().difference(this);
     }
 
+    @Override
     public Iterator<IpResource> iterator() {
         return Collections.unmodifiableMap(resourcesByEndPoint).values().iterator();
     }

--- a/src/main/java/net/ripe/ipresource/ImmutableResourceSet.java
+++ b/src/main/java/net/ripe/ipresource/ImmutableResourceSet.java
@@ -43,9 +43,6 @@ import java.util.stream.StreamSupport;
  * normalized into single resources.
  */
 public final class ImmutableResourceSet implements Iterable<IpResource>, Serializable {
-    public static final IpResourceRange ALL_AS_RESOURCES = IpResourceRange.parse(String.format("AS%d-AS%d", Asn.ASN_MIN_VALUE, Asn.ASN32_MAX_VALUE));
-    public static final IpRange ALL_IPV4_RESOURCES = IpRange.parse("0.0.0.0/0");
-    public static final IpRange ALL_IPV6_RESOURCES = IpRange.parse("::/0");
 
     public static final ImmutableResourceSet IP_PRIVATE_USE_RESOURCES = ImmutableResourceSet.of(IpResourceSet.IP_PRIVATE_USE_RESOURCES);
     public static final ImmutableResourceSet ASN_PRIVATE_USE_RESOURCES = ImmutableResourceSet.of(IpResourceSet.ASN_PRIVATE_USE_RESOURCES);
@@ -54,7 +51,7 @@ public final class ImmutableResourceSet implements Iterable<IpResource>, Seriali
     private static final long serialVersionUID = 1L;
 
     private static final ImmutableResourceSet EMPTY = new ImmutableResourceSet();
-    private static final ImmutableResourceSet UNIVERSAL = ImmutableResourceSet.of(ALL_AS_RESOURCES, ALL_IPV4_RESOURCES, ALL_IPV6_RESOURCES);
+    private static final ImmutableResourceSet UNIVERSAL = ImmutableResourceSet.of(IpResource.ALL_AS_RESOURCES, IpResource.ALL_IPV4_RESOURCES, IpResource.ALL_IPV6_RESOURCES);
 
     /*
      * Resources keyed by their end-point. This allows fast lookup to find potentially overlapping resources:

--- a/src/main/java/net/ripe/ipresource/ImmutableResourceSet.java
+++ b/src/main/java/net/ripe/ipresource/ImmutableResourceSet.java
@@ -47,9 +47,9 @@ public final class ImmutableResourceSet implements Iterable<IpResource>, Seriali
     public static final IpRange ALL_IPV4_RESOURCES = IpRange.parse("0.0.0.0/0");
     public static final IpRange ALL_IPV6_RESOURCES = IpRange.parse("::/0");
 
-    public static final ImmutableResourceSet IP_PRIVATE_USE_RESOURCES = ImmutableResourceSet.parse("10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,fc00::/7");
-    public static final ImmutableResourceSet ASN_PRIVATE_USE_RESOURCES = ImmutableResourceSet.parse("AS64512-AS65534");
-    public static final ImmutableResourceSet ALL_PRIVATE_USE_RESOURCES = ASN_PRIVATE_USE_RESOURCES.union(IP_PRIVATE_USE_RESOURCES);
+    public static final ImmutableResourceSet IP_PRIVATE_USE_RESOURCES = ImmutableResourceSet.of(IpResourceSet.IP_PRIVATE_USE_RESOURCES);
+    public static final ImmutableResourceSet ASN_PRIVATE_USE_RESOURCES = ImmutableResourceSet.of(IpResourceSet.ASN_PRIVATE_USE_RESOURCES);
+    public static final ImmutableResourceSet ALL_PRIVATE_USE_RESOURCES = ImmutableResourceSet.of(IpResourceSet.ALL_PRIVATE_USE_RESOURCES);
 
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/net/ripe/ipresource/ImmutableResourceSet.java
+++ b/src/main/java/net/ripe/ipresource/ImmutableResourceSet.java
@@ -200,7 +200,7 @@ public final class ImmutableResourceSet implements Iterable<IpResource>, Seriali
         return potentialMatch != null && potentialMatch.getValue().contains(resource);
     }
 
-    public boolean contains(ImmutableResourceSet other) {
+    public boolean contains(Iterable<? extends IpResource> other) {
         for (IpResource resource: other) {
             if (!contains(resource)) {
                 return false;

--- a/src/main/java/net/ripe/ipresource/ImmutableResourceSet.java
+++ b/src/main/java/net/ripe/ipresource/ImmutableResourceSet.java
@@ -58,7 +58,7 @@ public final class ImmutableResourceSet implements Iterable<IpResource>, Seriali
      *
      * resourcesByEndPoint.ceilingEntry(resourceToLookup.getStart())
      */
-    private final TreeMap<UniqueIpResource, IpResource> resourcesByEndPoint;
+    final TreeMap<UniqueIpResource, IpResource> resourcesByEndPoint;
 
     private ImmutableResourceSet() {
         this.resourcesByEndPoint = new TreeMap<>();
@@ -83,12 +83,18 @@ public final class ImmutableResourceSet implements Iterable<IpResource>, Seriali
         return resources.length == 0 ? empty() : ImmutableResourceSet.of(Arrays.asList(resources));
     }
 
-    public static ImmutableResourceSet of(Collection<? extends IpResource> resources) {
-        return resources.isEmpty() ? empty() : new Builder(resources).build();
+    public static ImmutableResourceSet of(Iterable<? extends IpResource> resources) {
+        if (resources instanceof ImmutableResourceSet) {
+            return (ImmutableResourceSet) resources;
+        } else if (resources instanceof IpResourceSet) {
+            return of((IpResourceSet) resources);
+        } else {
+            return new Builder(resources).build();
+        }
     }
 
     public static ImmutableResourceSet of(IpResourceSet resources) {
-        return resources.isEmpty() ? empty() : new Builder(resources).build();
+        return resources.isEmpty() ? empty() : new ImmutableResourceSet(resources.resourcesByEndPoint);
     }
 
     public static ImmutableResourceSet empty() {
@@ -291,10 +297,20 @@ public final class ImmutableResourceSet implements Iterable<IpResource>, Seriali
             this.resourcesByEndPoint = new TreeMap<>(resources.resourcesByEndPoint);
         }
 
+        public Builder(IpResourceSet resources) {
+            this.resourcesByEndPoint = new TreeMap<>(resources.resourcesByEndPoint);
+        }
+
         public Builder(Iterable<? extends IpResource> resources) {
-            this();
-            for (IpResource resource : resources) {
-                add(resource);
+            if (resources instanceof ImmutableResourceSet) {
+                this.resourcesByEndPoint = new TreeMap<>(((ImmutableResourceSet) resources).resourcesByEndPoint);
+            } else if (resources instanceof IpResourceSet) {
+                this.resourcesByEndPoint = new TreeMap<>(((IpResourceSet) resources).resourcesByEndPoint);
+            } else {
+                this.resourcesByEndPoint = new TreeMap<>();
+                for (IpResource resource : resources) {
+                    add(resource);
+                }
             }
         }
 

--- a/src/main/java/net/ripe/ipresource/ImmutableResourceSet.java
+++ b/src/main/java/net/ripe/ipresource/ImmutableResourceSet.java
@@ -1,0 +1,327 @@
+/**
+ * The BSD License
+ *
+ * Copyright (c) 2010-2012 RIPE NCC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the RIPE NCC nor the names of its contributors may be
+ *     used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.ripe.ipresource;
+
+import org.apache.commons.lang3.Validate;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.NavigableMap;
+import java.util.Objects;
+import java.util.Spliterator;
+import java.util.TreeMap;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * An immutable set of IP resources. Resources can be ASNs, IPv4 addresses, IPv6
+ * addresses, or ranges. Adjacent resources are merged. Single-sized ranges are
+ * normalized into single resources.
+ */
+public final class ImmutableResourceSet implements Iterable<IpResource>, Serializable {
+    public static final IpResourceRange ALL_AS_RESOURCES = IpResourceRange.parse(String.format("AS%d-AS%d", Asn.ASN_MIN_VALUE, Asn.ASN32_MAX_VALUE));
+    public static final IpRange ALL_IPV4_RESOURCES = IpRange.parse("0.0.0.0/0");
+    public static final IpRange ALL_IPV6_RESOURCES = IpRange.parse("::/0");
+
+    public static final ImmutableResourceSet IP_PRIVATE_USE_RESOURCES = ImmutableResourceSet.parse("10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,fc00::/7");
+    public static final ImmutableResourceSet ASN_PRIVATE_USE_RESOURCES = ImmutableResourceSet.parse("AS64512-AS65534");
+    public static final ImmutableResourceSet ALL_PRIVATE_USE_RESOURCES = ImmutableResourceSet.parse("AS64512-AS65534,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,fc00::/7");
+
+    private static final long serialVersionUID = 1L;
+
+    private static final ImmutableResourceSet EMPTY = new ImmutableResourceSet();
+    private static final ImmutableResourceSet UNIVERSAL = new ImmutableResourceSet(ALL_AS_RESOURCES, ALL_IPV4_RESOURCES, ALL_IPV6_RESOURCES);
+
+    /*
+     * Resources keyed by their end-point. This allows fast lookup to find potentially overlapping resources:
+     *
+     * resourcesByEndPoint.ceilingEntry(resourceToLookup.getStart())
+     */
+    private final NavigableMap<IpResource, IpResource> resourcesByEndPoint;
+
+    private ImmutableResourceSet() {
+        this.resourcesByEndPoint = new TreeMap<>();
+    }
+
+    public ImmutableResourceSet(ImmutableResourceSet resources) {
+        this.resourcesByEndPoint = new TreeMap<>(resources.resourcesByEndPoint);
+    }
+
+    public ImmutableResourceSet(IpResource... resources) {
+        this();
+        for (IpResource resource : resources) {
+            doAdd(resource);
+        }
+    }
+
+    public ImmutableResourceSet(Collection<? extends IpResource> resources) {
+        this();
+        for (IpResource resource : resources) {
+            doAdd(resource);
+        }
+    }
+
+    public ImmutableResourceSet(IpResourceSet resources) {
+        this.resourcesByEndPoint = new TreeMap<>(resources.resourcesByEndPoint);
+    }
+
+    private ImmutableResourceSet(NavigableMap<IpResource, IpResource> resourcesByEndPoint) {
+        this.resourcesByEndPoint = resourcesByEndPoint;
+    }
+
+    public static ImmutableResourceSet empty() {
+        return EMPTY;
+    }
+
+    public static ImmutableResourceSet universal() {
+        return UNIVERSAL;
+    }
+
+    public static ImmutableResourceSet of(IpResource... resources) {
+        return new ImmutableResourceSet(resources);
+    }
+
+    public static Collector<IpResource, IpResourceSet, ImmutableResourceSet> collector() {
+        return Collector.of(
+            IpResourceSet::new,
+            IpResourceSet::add,
+            (a, b) -> {
+                IpResourceSet r = new IpResourceSet(a);
+                a.addAll(b);
+                return r;
+            },
+            ImmutableResourceSet::new
+        );
+    }
+
+    public ImmutableResourceSet add(IpResource value) {
+        if (this.contains(value)) {
+            return this;
+        } else {
+            ImmutableResourceSet result = new ImmutableResourceSet(this);
+            result.doAdd(value);
+            return result;
+        }
+    }
+
+    public  ImmutableResourceSet remove(IpResource value) {
+        ImmutableResourceSet result = new ImmutableResourceSet(this);
+        result.doRemove(value);
+        return result;
+    }
+
+    public ImmutableResourceSet union(ImmutableResourceSet that) {
+        if (this.isEmpty()) {
+            return that;
+        } else if (that.isEmpty()) {
+            return this;
+        } else if (this.resourcesByEndPoint.size() < that.resourcesByEndPoint.size()) {
+            ImmutableResourceSet result = new ImmutableResourceSet(that);
+            result.doAddAll(this);
+            return result;
+        } else {
+            ImmutableResourceSet result = new ImmutableResourceSet(this);
+            result.doAddAll(that);
+            return result;
+        }
+    }
+
+    public ImmutableResourceSet intersection(ImmutableResourceSet that) {
+        if (this.isEmpty()) {
+            return this;
+        } else if (that.isEmpty()) {
+            return that;
+        } else {
+            NavigableMap<IpResource, IpResource> temp = new TreeMap<>();
+            Iterator<IpResource> thisIterator = this.iterator();
+            Iterator<IpResource> thatIterator = that.iterator();
+            IpResource thisResource = thisIterator.next();
+            IpResource thatResource = thatIterator.next();
+            while (thisResource != null && thatResource != null) {
+                IpResource intersect = thisResource.intersect(thatResource);
+                if (intersect != null) {
+                    temp.put(intersect.getEnd(), normalize(intersect));
+                }
+                int compareTo = thisResource.getEnd().compareTo(thatResource.getEnd());
+                if (compareTo <= 0) {
+                    thisResource = thisIterator.hasNext() ? thisIterator.next() : null;
+                }
+                if (compareTo >= 0) {
+                    thatResource = thatIterator.hasNext() ? thatIterator.next() : null;
+                }
+            }
+            return new ImmutableResourceSet(temp);
+        }
+    }
+
+    public ImmutableResourceSet difference(ImmutableResourceSet that) {
+        if (this.isEmpty() || that.isEmpty()) {
+            return this;
+        } else {
+            ImmutableResourceSet result = new ImmutableResourceSet(this);
+            for (IpResource resource: that) {
+                result.doRemove(resource);
+            }
+            return result;
+        }
+    }
+
+    public ImmutableResourceSet complement() {
+        return universal().difference(this);
+    }
+
+    public Iterator<IpResource> iterator() {
+        return Collections.unmodifiableMap(resourcesByEndPoint).values().iterator();
+    }
+
+    @Override
+    public Spliterator<IpResource> spliterator() {
+        return Collections.unmodifiableMap(resourcesByEndPoint).values().spliterator();
+    }
+
+    public Stream<IpResource> stream() {
+        return StreamSupport.stream(spliterator(), false);
+    }
+
+    public boolean isEmpty() {
+        return resourcesByEndPoint.isEmpty();
+    }
+
+    public boolean contains(IpResource resource) {
+        Entry<IpResource, IpResource> potentialMatch = resourcesByEndPoint.ceilingEntry(resource.getStart());
+        return potentialMatch != null && potentialMatch.getValue().contains(resource);
+    }
+
+    public boolean contains(ImmutableResourceSet other) {
+        for (IpResource resource: other) {
+            if (!contains(resource)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public boolean containsType(IpResourceType type) {
+        for (IpResource resource: resourcesByEndPoint.values()) {
+            if (type == resource.getType()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static ImmutableResourceSet parse(String s) {
+        String[] resources = s.split(",");
+        ImmutableResourceSet result = new ImmutableResourceSet();
+        for (String r : resources) {
+            String trimmed = r.trim();
+            if (!trimmed.isEmpty()) {
+                result.doAdd(IpResource.parse(trimmed));
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return resourcesByEndPoint.values().stream().map(Objects::toString).collect(Collectors.joining(", "));
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (! (obj instanceof ImmutableResourceSet)) {
+            return false;
+        }
+        ImmutableResourceSet other = (ImmutableResourceSet) obj;
+        return resourcesByEndPoint.equals(other.resourcesByEndPoint);
+    }
+
+    @Override
+    public int hashCode() {
+        return resourcesByEndPoint.hashCode();
+    }
+
+    private void doAddAll(ImmutableResourceSet ipResourceSet) {
+        for (IpResource ipResource: ipResourceSet.resourcesByEndPoint.values()) {
+            doAdd(ipResource);
+        }
+    }
+
+    private void doAdd(IpResource resource) {
+        Validate.notNull(resource, "resource is null");
+
+        UniqueIpResource start = resource.getStart();
+        if (!start.equals(start.getType().getMinimum())) {
+            start = start.predecessor();
+        }
+
+        IpResource resourceToAdd = normalize(resource);
+
+        Iterator<IpResource> iterator = resourcesByEndPoint.tailMap(start, true).values().iterator();
+        while (iterator.hasNext()) {
+            IpResource potentialMatch = iterator.next();
+            if (resourceToAdd.isMergeable(potentialMatch)) {
+                iterator.remove();
+                resourceToAdd = resourceToAdd.merge(potentialMatch);
+            } else {
+                break;
+            }
+        }
+
+        IpResource normalized = normalize(resourceToAdd);
+        resourcesByEndPoint.put(normalized.getEnd(), normalized);
+    }
+
+    private void doRemove(IpResource resource) {
+        Entry<IpResource, IpResource> potentialMatch = resourcesByEndPoint.ceilingEntry(resource.getStart());
+        while (potentialMatch != null && potentialMatch.getValue().overlaps(resource)) {
+            resourcesByEndPoint.remove(potentialMatch.getKey());
+
+            for (IpResource remains: potentialMatch.getValue().subtract(resource)) {
+                doAdd(remains);
+            }
+
+            potentialMatch = resourcesByEndPoint.ceilingEntry(resource.getStart());
+        }
+    }
+
+    private static IpResource normalize(IpResource resource) {
+        return resource.isUnique() ? resource.unique() : resource;
+    }
+
+}

--- a/src/main/java/net/ripe/ipresource/ImmutableResourceSet.java
+++ b/src/main/java/net/ripe/ipresource/ImmutableResourceSet.java
@@ -45,7 +45,7 @@ import java.util.stream.StreamSupport;
 public final class ImmutableResourceSet implements Iterable<IpResource>, Serializable {
 
     public static final ImmutableResourceSet IP_PRIVATE_USE_RESOURCES = ImmutableResourceSet.parse("10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,fc00::/7");
-    public static final ImmutableResourceSet ASN_PRIVATE_USE_RESOURCES = ImmutableResourceSet.parse("AS64512-AS65534");
+    public static final ImmutableResourceSet ASN_PRIVATE_USE_RESOURCES = ImmutableResourceSet.parse("AS64512-AS65534,AS4200000000-AS4294967294");
     public static final ImmutableResourceSet ALL_PRIVATE_USE_RESOURCES = ASN_PRIVATE_USE_RESOURCES.union(IP_PRIVATE_USE_RESOURCES);
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/net/ripe/ipresource/IpResource.java
+++ b/src/main/java/net/ripe/ipresource/IpResource.java
@@ -38,6 +38,10 @@ import java.util.List;
 
 public abstract class IpResource implements Serializable, Comparable<IpResource> {
 
+    public static final IpResourceRange ALL_AS_RESOURCES = IpResourceRange.range(new Asn(Asn.ASN_MIN_VALUE), new Asn(Asn.ASN32_MAX_VALUE));
+    public static final IpRange ALL_IPV4_RESOURCES = IpRange.parse("0.0.0.0/0");
+    public static final IpRange ALL_IPV6_RESOURCES = IpRange.parse("::/0");
+
     private static final long serialVersionUID = 1L;
 
     public abstract IpResourceType getType();

--- a/src/main/java/net/ripe/ipresource/IpResourceSet.java
+++ b/src/main/java/net/ripe/ipresource/IpResourceSet.java
@@ -62,14 +62,14 @@ public class IpResourceSet implements Iterable<IpResource>, Serializable {
      *
      * resourcesByEndPoint.ceilingEntry(resourceToLookup.getStart())
      */
-    private TreeMap<IpResource, IpResource> resourcesByEndPoint;
+    private TreeMap<UniqueIpResource, IpResource> resourcesByEndPoint;
 
     public IpResourceSet() {
-        this.resourcesByEndPoint = new TreeMap<IpResource, IpResource>();
+        this.resourcesByEndPoint = new TreeMap<>();
     }
 
     public IpResourceSet(IpResourceSet resources) {
-        this.resourcesByEndPoint = new TreeMap<IpResource, IpResource>(resources.resourcesByEndPoint);
+        this.resourcesByEndPoint = new TreeMap<>(resources.resourcesByEndPoint);
     }
 
     public IpResourceSet(IpResource... resources) {
@@ -119,7 +119,7 @@ public class IpResourceSet implements Iterable<IpResource>, Serializable {
     }
 
     public boolean contains(IpResource resource) {
-        Entry<IpResource, IpResource> potentialMatch = resourcesByEndPoint.ceilingEntry(resource.getStart());
+        Entry<UniqueIpResource, IpResource> potentialMatch = resourcesByEndPoint.ceilingEntry(resource.getStart());
         return potentialMatch != null && potentialMatch.getValue().contains(resource);
     }
 
@@ -160,7 +160,7 @@ public class IpResourceSet implements Iterable<IpResource>, Serializable {
     public boolean remove(IpResource resource) {
         boolean removed = false;
 
-        Entry<IpResource, IpResource> potentialMatch = resourcesByEndPoint.ceilingEntry(resource.getStart());
+        Entry<UniqueIpResource, IpResource> potentialMatch = resourcesByEndPoint.ceilingEntry(resource.getStart());
         while (potentialMatch != null && potentialMatch.getValue().overlaps(resource)) {
             resourcesByEndPoint.remove(potentialMatch.getKey());
             removed = true;
@@ -189,7 +189,7 @@ public class IpResourceSet implements Iterable<IpResource>, Serializable {
             return;
         }
 
-        TreeMap<IpResource, IpResource> temp = new TreeMap<IpResource, IpResource>();
+        TreeMap<UniqueIpResource, IpResource> temp = new TreeMap<>();
         Iterator<IpResource> thisIterator = this.iterator();
         Iterator<IpResource> thatIterator = other.iterator();
         IpResource thisResource = thisIterator.next();
@@ -241,10 +241,10 @@ public class IpResourceSet implements Iterable<IpResource>, Serializable {
     private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
         ObjectInputStream.GetField gf = in.readFields();
         if (!gf.defaulted("resourcesByEndPoint")) {
-            resourcesByEndPoint = (TreeMap<IpResource, IpResource>) gf.get("resourcesByEndPoint", null);
+            resourcesByEndPoint = (TreeMap<UniqueIpResource, IpResource>) gf.get("resourcesByEndPoint", null);
         } else {
             SortedSet<IpResource> resources = (SortedSet<IpResource>) gf.get("resources", null);
-            resourcesByEndPoint = new TreeMap<IpResource, IpResource>();
+            resourcesByEndPoint = new TreeMap<>();
             for (IpResource resource: resources) {
                 resourcesByEndPoint.put(resource.getEnd(), resource);
             }

--- a/src/main/java/net/ripe/ipresource/IpResourceSet.java
+++ b/src/main/java/net/ripe/ipresource/IpResourceSet.java
@@ -73,13 +73,17 @@ public class IpResourceSet implements Iterable<IpResource>, Serializable {
      *
      * resourcesByEndPoint.ceilingEntry(resourceToLookup.getStart())
      */
-    private TreeMap<UniqueIpResource, IpResource> resourcesByEndPoint;
+    TreeMap<UniqueIpResource, IpResource> resourcesByEndPoint;
 
     public IpResourceSet() {
         this.resourcesByEndPoint = new TreeMap<>();
     }
 
     public IpResourceSet(IpResourceSet resources) {
+        this.resourcesByEndPoint = new TreeMap<>(resources.resourcesByEndPoint);
+    }
+
+    public IpResourceSet(ImmutableResourceSet resources) {
         this.resourcesByEndPoint = new TreeMap<>(resources.resourcesByEndPoint);
     }
 
@@ -91,16 +95,19 @@ public class IpResourceSet implements Iterable<IpResource>, Serializable {
     }
 
     public IpResourceSet(Collection<? extends IpResource> resources) {
-        this();
-        for (IpResource resource : resources) {
-            add(resource);
-        }
+        this((Iterable<? extends IpResource>) resources);
     }
 
     public IpResourceSet(Iterable<? extends IpResource> resources) {
-        this();
-        for (IpResource resource : resources) {
-            add(resource);
+        if (resources instanceof IpResourceSet) {
+            this.resourcesByEndPoint = new TreeMap<>(((IpResourceSet) resources).resourcesByEndPoint);
+        } else if (resources instanceof ImmutableResourceSet) {
+            this.resourcesByEndPoint = new TreeMap<>(((ImmutableResourceSet) resources).resourcesByEndPoint);
+        } else {
+            this.resourcesByEndPoint = new TreeMap<>();
+            for (IpResource resource : resources) {
+                add(resource);
+            }
         }
     }
 

--- a/src/main/java/net/ripe/ipresource/IpResourceSet.java
+++ b/src/main/java/net/ripe/ipresource/IpResourceSet.java
@@ -44,6 +44,9 @@ import java.util.TreeMap;
  * A mutable set of IP resources. Resources can be ASNs, IPv4 addresses, IPv6
  * addresses, or ranges. Adjacent resources are merged. Single-sized ranges are
  * normalized into single resources.
+ * <p>
+ *     Note: the {@link ImmutableResourceSet} is now preferred to this class.
+ * </p>
  */
 public class IpResourceSet implements Iterable<IpResource>, Serializable {
 

--- a/src/main/java/net/ripe/ipresource/IpResourceSet.java
+++ b/src/main/java/net/ripe/ipresource/IpResourceSet.java
@@ -98,21 +98,18 @@ public class IpResourceSet implements Iterable<IpResource>, Serializable {
             start = start.predecessor();
         }
 
-        IpResource resourceToAdd = normalize(resource);
-
         Iterator<IpResource> iterator = resourcesByEndPoint.tailMap(start, true).values().iterator();
         while (iterator.hasNext()) {
             IpResource potentialMatch = iterator.next();
-            if (resourceToAdd.isMergeable(potentialMatch)) {
+            if (resource.isMergeable(potentialMatch)) {
                 iterator.remove();
-                resourceToAdd = resourceToAdd.merge(potentialMatch);
+                resource = resource.merge(potentialMatch);
             } else {
                 break;
             }
         }
 
-        IpResource normalized = normalize(resourceToAdd);
-        resourcesByEndPoint.put(normalized.getEnd(), normalized);
+        resourcesByEndPoint.put(resource.getEnd(), normalize(resource));
     }
 
     public boolean isEmpty() {
@@ -235,7 +232,7 @@ public class IpResourceSet implements Iterable<IpResource>, Serializable {
     }
 
     private IpResource normalize(IpResource resource) {
-        return resource.isUnique() ? resource.unique() : resource;
+        return resource.isUnique() ? resource.getStart() : resource;
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/net/ripe/ipresource/IpResourceSet.java
+++ b/src/main/java/net/ripe/ipresource/IpResourceSet.java
@@ -49,9 +49,21 @@ import java.util.stream.StreamSupport;
  */
 public class IpResourceSet implements Iterable<IpResource>, Serializable {
 
-    public static final IpResourceSet IP_PRIVATE_USE_RESOURCES = IpResourceSet.parse("10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,fc00::/7");
-    public static final IpResourceSet ASN_PRIVATE_USE_RESOURCES = IpResourceSet.parse("AS64512-AS65534");
-    public static final IpResourceSet ALL_PRIVATE_USE_RESOURCES = IpResourceSet.parse("AS64512-AS65534,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,fc00::/7");
+    /**
+     * @deprecated it is not safe to use this constant since the {@code IpResourceSet} can be mutated.
+     */
+    @Deprecated
+    public static final IpResourceSet IP_PRIVATE_USE_RESOURCES = new IpResourceSet(ImmutableResourceSet.IP_PRIVATE_USE_RESOURCES);
+    /**
+     * @deprecated it is not safe to use this constant since the {@code IpResourceSet} can be mutated.
+     */
+    @Deprecated
+    public static final IpResourceSet ASN_PRIVATE_USE_RESOURCES = new IpResourceSet(ImmutableResourceSet.ASN_PRIVATE_USE_RESOURCES);
+    /**
+     * @deprecated it is not safe to use this constant since the {@code IpResourceSet} can be mutated.
+     */
+    @Deprecated
+    public static final IpResourceSet ALL_PRIVATE_USE_RESOURCES = new IpResourceSet(ImmutableResourceSet.ALL_PRIVATE_USE_RESOURCES);
 
     private static final long serialVersionUID = 1L;
 
@@ -79,6 +91,13 @@ public class IpResourceSet implements Iterable<IpResource>, Serializable {
     }
 
     public IpResourceSet(Collection<? extends IpResource> resources) {
+        this();
+        for (IpResource resource : resources) {
+            add(resource);
+        }
+    }
+
+    public IpResourceSet(Iterable<? extends IpResource> resources) {
         this();
         for (IpResource resource : resources) {
             add(resource);

--- a/src/main/java/net/ripe/ipresource/IpResourceSet.java
+++ b/src/main/java/net/ripe/ipresource/IpResourceSet.java
@@ -37,7 +37,6 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map.Entry;
-import java.util.NavigableMap;
 import java.util.SortedSet;
 import java.util.TreeMap;
 
@@ -60,7 +59,7 @@ public class IpResourceSet implements Iterable<IpResource>, Serializable {
      *
      * resourcesByEndPoint.ceilingEntry(resourceToLookup.getStart())
      */
-    NavigableMap<IpResource, IpResource> resourcesByEndPoint;
+    private TreeMap<IpResource, IpResource> resourcesByEndPoint;
 
     public IpResourceSet() {
         this.resourcesByEndPoint = new TreeMap<IpResource, IpResource>();
@@ -187,7 +186,7 @@ public class IpResourceSet implements Iterable<IpResource>, Serializable {
             return;
         }
 
-        NavigableMap<IpResource, IpResource> temp = new TreeMap<IpResource, IpResource>();
+        TreeMap<IpResource, IpResource> temp = new TreeMap<IpResource, IpResource>();
         Iterator<IpResource> thisIterator = this.iterator();
         Iterator<IpResource> thatIterator = other.iterator();
         IpResource thisResource = thisIterator.next();
@@ -239,7 +238,7 @@ public class IpResourceSet implements Iterable<IpResource>, Serializable {
     private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
         ObjectInputStream.GetField gf = in.readFields();
         if (!gf.defaulted("resourcesByEndPoint")) {
-            resourcesByEndPoint = (NavigableMap<IpResource, IpResource>) gf.get("resourcesByEndPoint", null);
+            resourcesByEndPoint = (TreeMap<IpResource, IpResource>) gf.get("resourcesByEndPoint", null);
         } else {
             SortedSet<IpResource> resources = (SortedSet<IpResource>) gf.get("resources", null);
             resourcesByEndPoint = new TreeMap<IpResource, IpResource>();

--- a/src/main/java/net/ripe/ipresource/IpResourceSet.java
+++ b/src/main/java/net/ripe/ipresource/IpResourceSet.java
@@ -60,7 +60,7 @@ public class IpResourceSet implements Iterable<IpResource>, Serializable {
      *
      * resourcesByEndPoint.ceilingEntry(resourceToLookup.getStart())
      */
-    private NavigableMap<IpResource, IpResource> resourcesByEndPoint;
+    NavigableMap<IpResource, IpResource> resourcesByEndPoint;
 
     public IpResourceSet() {
         this.resourcesByEndPoint = new TreeMap<IpResource, IpResource>();

--- a/src/main/java/net/ripe/ipresource/IpResourceSet.java
+++ b/src/main/java/net/ripe/ipresource/IpResourceSet.java
@@ -34,11 +34,10 @@ import org.apache.commons.lang3.Validate;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
-import java.util.Collection;
-import java.util.Iterator;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.SortedSet;
-import java.util.TreeMap;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * A mutable set of IP resources. Resources can be ASNs, IPv4 addresses, IPv6
@@ -153,8 +152,19 @@ public class IpResourceSet implements Iterable<IpResource>, Serializable {
         return result;
     }
 
+    @Override
     public Iterator<IpResource> iterator() {
         return resourcesByEndPoint.values().iterator();
+    }
+
+    @Override
+    public Spliterator<IpResource> spliterator() {
+        return Spliterators.spliterator(resourcesByEndPoint.values(),
+            Spliterator.DISTINCT | Spliterator.SORTED);
+    }
+
+    public Stream<IpResource> stream() {
+        return StreamSupport.stream(spliterator(), false);
     }
 
     public boolean remove(IpResource resource) {

--- a/src/main/java/net/ripe/ipresource/IpResourceType.java
+++ b/src/main/java/net/ripe/ipresource/IpResourceType.java
@@ -59,7 +59,9 @@ public enum IpResourceType {
 
     private final String description;
     private final int bitSize;
-    
+    private final UniqueIpResource minimum = fromBigInteger(BigInteger.ZERO);
+    private final UniqueIpResource maximum = fromBigInteger(BigInteger.ONE.shiftLeft(getBitSize()).subtract(BigInteger.ONE));
+
     private IpResourceType(String description, int bitSize) {
         this.description = description;
         this.bitSize = bitSize;
@@ -82,13 +84,13 @@ public enum IpResourceType {
     }
 
     public UniqueIpResource getMinimum() {
-        return fromBigInteger(BigInteger.ZERO);
+        return minimum;
     }
     
     public UniqueIpResource getMaximum() {
-        return fromBigInteger(BigInteger.ONE.shiftLeft(getBitSize()).subtract(BigInteger.ONE));
+        return maximum;
     }
-    
+
     public abstract UniqueIpResource fromBigInteger(BigInteger value);
 
     /**

--- a/src/main/java/net/ripe/ipresource/UniqueIpResource.java
+++ b/src/main/java/net/ripe/ipresource/UniqueIpResource.java
@@ -74,12 +74,17 @@ public abstract class UniqueIpResource extends IpResource {
     @Override
     protected int doCompareTo(IpResource obj) {
         if (obj instanceof UniqueIpResource) {
-            throw new IllegalStateException("should be overriden by subclass");
+            throw new IllegalStateException("should be overridden by subclass");
         } else if (obj instanceof IpResourceRange) {
             return upTo(this).compareTo(obj);
         } else {
             throw new IllegalArgumentException("not a valid resource type: " + obj);
         }
+    }
+
+    @Override
+    public boolean isUnique() {
+        return true;
     }
 
     @Override

--- a/src/test/java/net/ripe/ipresource/ImmutableResourceSetTest.java
+++ b/src/test/java/net/ripe/ipresource/ImmutableResourceSetTest.java
@@ -199,6 +199,26 @@ public class ImmutableResourceSetTest {
     }
 
     @Test
+    public void test_intersects() {
+        for (int i = 0; i < RANDOM_SIZE; ++i) {
+            ImmutableResourceSet a = randomSet(i);
+
+            assertFalse(a.intersects(empty()));
+            assertFalse(a.intersects(a.complement()));
+            assertTrue(a.isEmpty() || a.intersects(a));
+            assertTrue(a.isEmpty() || a.intersects(universal()));
+        }
+
+        for (int i = 0; i < RANDOM_SIZE; ++i) {
+            ImmutableResourceSet a = randomSet(i);
+            ImmutableResourceSet b = randomSet(i);
+
+            assertTrue(a.isEmpty() || b.isEmpty() || (a.union(b).intersects(a) && a.union(b).intersects(b)));
+            assertTrue(a.intersection(b).isEmpty() != a.intersects(b));
+        }
+    }
+
+    @Test
     public void union_is_associative() {
         for (int i = 0; i < RANDOM_SIZE; ++i) {
             ImmutableResourceSet a = randomSet(i);

--- a/src/test/java/net/ripe/ipresource/ImmutableResourceSetTest.java
+++ b/src/test/java/net/ripe/ipresource/ImmutableResourceSetTest.java
@@ -80,9 +80,12 @@ public class ImmutableResourceSetTest {
 
     @Test
     public void should_have_constants_for_private_use_resources() {
-        assertEquals("AS64512-AS65534", ImmutableResourceSet.ASN_PRIVATE_USE_RESOURCES.toString());
+        assertEquals("AS64512-AS65534, AS4200000000-AS4294967294", ImmutableResourceSet.ASN_PRIVATE_USE_RESOURCES.toString());
         assertEquals("10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, fc00::/7", ImmutableResourceSet.IP_PRIVATE_USE_RESOURCES.toString());
-        assertEquals("AS64512-AS65534, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, fc00::/7", ImmutableResourceSet.ALL_PRIVATE_USE_RESOURCES.toString());
+        assertEquals(
+            "AS64512-AS65534, AS4200000000-AS4294967294, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, fc00::/7",
+            ImmutableResourceSet.ALL_PRIVATE_USE_RESOURCES.toString()
+        );
     }
 
     @Test

--- a/src/test/java/net/ripe/ipresource/ImmutableResourceSetTest.java
+++ b/src/test/java/net/ripe/ipresource/ImmutableResourceSetTest.java
@@ -66,6 +66,13 @@ public class ImmutableResourceSetTest {
     }
 
     @Test
+    public void should_have_constants_for_private_use_resources() {
+        assertEquals("AS64512-AS65534", ImmutableResourceSet.ASN_PRIVATE_USE_RESOURCES.toString());
+        assertEquals("10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, fc00::/7", ImmutableResourceSet.IP_PRIVATE_USE_RESOURCES.toString());
+        assertEquals("AS64512-AS65534, 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, fc00::/7", ImmutableResourceSet.ALL_PRIVATE_USE_RESOURCES.toString());
+    }
+
+    @Test
     public void containsAllIpv4Resources() {
         ImmutableResourceSet resources = ImmutableResourceSet.of(parse("0.0.0.0/0"));
         assertEquals("0.0.0.0/0", resources.toString());

--- a/src/test/java/net/ripe/ipresource/ImmutableResourceSetTest.java
+++ b/src/test/java/net/ripe/ipresource/ImmutableResourceSetTest.java
@@ -53,13 +53,13 @@ public class ImmutableResourceSetTest {
 
     @Test
     public void containsAllIpv4Resources() {
-        ImmutableResourceSet resources = new ImmutableResourceSet(parse("0.0.0.0/0"));
+        ImmutableResourceSet resources = ImmutableResourceSet.of(parse("0.0.0.0/0"));
         assertEquals("0.0.0.0/0", resources.toString());
     }
 
     @Test
     public void shouldNormalizeAccordingToRfc3779() {
-        ImmutableResourceSet resources = new ImmutableResourceSet(
+        ImmutableResourceSet resources = ImmutableResourceSet.of(
             parse("127.0.0.1"),
             parse("10.0.0.0/8"),
             parse("255.255.255.255-255.255.255.255"),

--- a/src/test/java/net/ripe/ipresource/ImmutableResourceSetTest.java
+++ b/src/test/java/net/ripe/ipresource/ImmutableResourceSetTest.java
@@ -58,8 +58,10 @@ public class ImmutableResourceSetTest {
         ImmutableResourceSet.Builder builder = new ImmutableResourceSet.Builder();
         builder.build();
 
-        assertThrows(IllegalStateException.class, () -> builder.add(IpAddress.parse("10.0.0.1")));
-        assertThrows(IllegalStateException.class, () -> builder.remove(IpAddress.parse("10.0.0.1")));
+        IpAddress address = IpAddress.parse("10.0.0.1");
+
+        assertThrows(IllegalStateException.class, () -> builder.add(address));
+        assertThrows(IllegalStateException.class, () -> builder.remove(address));
         assertThrows(IllegalStateException.class, () -> builder.addAll(ALL_PRIVATE_USE_RESOURCES));
         assertThrows(IllegalStateException.class, () -> builder.removeAll(ALL_PRIVATE_USE_RESOURCES));
         assertThrows(IllegalStateException.class, builder::build);

--- a/src/test/java/net/ripe/ipresource/ImmutableResourceSetTest.java
+++ b/src/test/java/net/ripe/ipresource/ImmutableResourceSetTest.java
@@ -1,0 +1,331 @@
+/**
+ * The BSD License
+ *
+ * Copyright (c) 2010-2012 RIPE NCC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *   - Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   - Neither the name of the RIPE NCC nor the names of its contributors may be
+ *     used to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.ripe.ipresource;
+
+import org.junit.Test;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+
+import static net.ripe.ipresource.ImmutableResourceSet.empty;
+import static net.ripe.ipresource.ImmutableResourceSet.universal;
+import static net.ripe.ipresource.IpResource.parse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ImmutableResourceSetTest {
+
+    public static final int RANDOM_SIZE = 1000;
+
+    @Test
+    public void containsAllIpv4Resources() {
+        ImmutableResourceSet resources = new ImmutableResourceSet(parse("0.0.0.0/0"));
+        assertEquals("0.0.0.0/0", resources.toString());
+    }
+
+    @Test
+    public void shouldNormalizeAccordingToRfc3779() {
+        ImmutableResourceSet resources = new ImmutableResourceSet(
+            parse("127.0.0.1"),
+            parse("10.0.0.0/8"),
+            parse("255.255.255.255-255.255.255.255"),
+            parse("193.0.0.0/8"),
+            parse("194.0.0.0/8"),
+            parse("194.16.0.0/16"),
+            parse("195.0.0.0/8"),
+            parse("195.1.0.0-196.255.255.255")
+        );
+        assertEquals("10.0.0.0/8, 127.0.0.1, 193.0.0.0-196.255.255.255, 255.255.255.255", resources.toString());
+    }
+
+    @Test
+    public void shouldNormalizeSingletonRangeToUniqueIpResource() {
+        IpResourceSet resources = new IpResourceSet(parse("127.0.0.1-127.0.0.1"));
+        assertEquals("127.0.0.1", resources.toString());
+    }
+
+    @Test
+    public void shouldMergeAdjacentResources_lowerPartFirst() {
+        ImmutableResourceSet subject = empty()
+            .add(parse("10.0.0.0/9"))
+            .add(parse("10.128.0.0/9"));
+
+        assertEquals("10.0.0.0/8", subject.toString());
+    }
+
+    @Test
+    public void shouldMergeAdjacentResources_higherPartFirst() {
+        ImmutableResourceSet subject = empty()
+            .add(parse("10.128.0.0/9"))
+            .add(parse("10.0.0.0/9"));
+
+        assertEquals("10.0.0.0/8", subject.toString());
+
+    }
+
+    @Test
+    public void shouldCheckForType() {
+        ImmutableResourceSet subject = ImmutableResourceSet.of(parse("AS13"));
+        assertTrue(subject.containsType(IpResourceType.ASN));
+        assertFalse(subject.containsType(IpResourceType.IPv4));
+    }
+
+    @Test
+    public void shouldNormalizeUniqueResources() {
+        ImmutableResourceSet subject = ImmutableResourceSet.of(parse("AS1-AS10"));
+        assertEquals(IpResourceRange.class, subject.iterator().next().getClass());
+
+        subject = subject.remove(parse("AS2-AS10"));
+        assertEquals(Asn.class, subject.iterator().next().getClass());
+        assertEquals("AS1", subject.toString());
+    }
+
+    @Test
+    public void shouldMergeOverlappingResources() {
+        ImmutableResourceSet subject = empty()
+            .add(parse("AS5-AS13"))
+            .add(parse("AS3-AS8"));
+
+        assertEquals("AS3-AS13", subject.toString());
+    }
+
+    @Test
+    public void parseShouldIgnoreWhitespace() {
+        assertEquals(ImmutableResourceSet.parse("127.0.0.1,AS3333"), ImmutableResourceSet.parse("\t   \n127.0.0.1,   AS3333"));
+    }
+
+    @Test
+    public void testContains() {
+        ImmutableResourceSet a = ImmutableResourceSet.parse("10.0.0.0/8,192.168.0.0/16");
+        assertTrue(a.contains(a));
+        assertTrue(a.contains(empty()));
+        assertTrue(empty().contains(empty()));
+        assertFalse(empty().contains(ImmutableResourceSet.parse("10.0.0.0/24")));
+
+        assertTrue(a.contains(ImmutableResourceSet.parse("10.0.0.0/24")));
+        assertTrue(a.contains(ImmutableResourceSet.parse("192.168.1.131")));
+        assertFalse(a.contains(ImmutableResourceSet.parse("127.0.0.1")));
+        assertFalse(a.contains(ImmutableResourceSet.parse("192.168.0.0-192.172.255.255")));
+        assertFalse(a.contains(ImmutableResourceSet.parse("10.0.0.1,192.168.0.0-192.172.255.255")));
+    }
+
+    @Test
+    public void testRemove() {
+        ImmutableResourceSet a = ImmutableResourceSet.parse("AS3333-AS4444,10.0.0.0/8").remove(IpResource.parse("10.5.0.0/16"));
+        assertEquals(ImmutableResourceSet.parse("AS3333-AS4444, 10.0.0.0-10.4.255.255, 10.6.0.0-10.255.255.255"), a);
+
+        assertTrue(a.contains(IpResource.parse("AS3333-AS4444")));
+
+        a = a.remove(parse("2000::/16"));
+        assertEquals("AS3333-AS4444, 10.0.0.0-10.4.255.255, 10.6.0.0-10.255.255.255", a.toString());
+    }
+
+    @Test
+    public void testRemoveAll() {
+        IpResourceSet a = IpResourceSet.parse("AS3333-AS4444,10.0.0.0/8");
+        a.removeAll(IpResourceSet.parse("10.5.0.0/16, AS3335"));
+        assertEquals(IpResourceSet.parse("AS3333-AS3334, AS3336-AS4444, 10.0.0.0-10.4.255.255, 10.6.0.0-10.255.255.255"), a);
+    }
+
+    @Test
+    public void testRetainAll() {
+        IpResourceSet empty = IpResourceSet.parse("");
+        empty.retainAll(IpResourceSet.parse("AS1-AS10,AS3300-AS4420,10.0.0.0/9"));
+        assertEquals("", empty.toString());
+
+        IpResourceSet a = IpResourceSet.parse("AS8-AS3315,AS3333-AS4444,10.0.0.0/8");
+        a.retainAll(IpResourceSet.parse("AS1-AS10,AS3300-AS4420,10.0.0.0/9"));
+        assertEquals(IpResourceSet.parse("AS8-AS10,AS3300-AS3315,AS3333-AS4420,10.0.0.0/9"), a);
+
+        a.retainAll(IpResourceSet.parse("AS3300-AS3320"));
+        assertEquals("AS3300-AS3315", a.toString());
+
+        a.retainAll(IpResourceSet.parse("AS3300-AS3320, 10.0.0.0/9"));
+        assertEquals("AS3300-AS3315", a.toString());
+
+        a.retainAll(empty);
+        assertTrue(a.isEmpty());
+        assertEquals("", a.toString());
+    }
+
+    @Test
+    public void shouldNormalizeRetainedResources() {
+        // Without normalization on retainAll the single IP resource was retained as the range AS64513-AS64513.
+        IpResourceSet subject = IpResourceSet.parse("AS64513");
+        subject.retainAll(IpResourceSet.ALL_PRIVATE_USE_RESOURCES);
+        assertEquals("AS64513", subject.toString());
+    }
+
+    @Test
+    public void test_removal_of_multiple_overlapping_resources() {
+        ImmutableResourceSet subject = ImmutableResourceSet.parse("AS1-AS3, AS5-AS10, AS13-AS15")
+            .remove(IpResource.parse("AS1-AS10"));
+        assertEquals("AS13-AS15", subject.toString());
+    }
+
+    @Test
+    public void union_is_associative() {
+        for (int i = 0; i < RANDOM_SIZE; ++i) {
+            ImmutableResourceSet a = randomSet(i);
+            ImmutableResourceSet b = randomSet(i);
+            ImmutableResourceSet c = randomSet(i);
+
+            assertEquals(a.union(b).union(c), a.union(b.union(c)));
+        }
+    }
+
+    @Test
+    public void union_is_commutative() {
+        for (int i = 0; i < RANDOM_SIZE; ++i) {
+            ImmutableResourceSet a = randomSet(i);
+            ImmutableResourceSet b = randomSet(i);
+
+            assertEquals(a.union(b), b.union(a));
+        }
+    }
+
+    @Test
+    public void intersection_is_associative() {
+        for (int i = 0; i < RANDOM_SIZE; ++i) {
+            ImmutableResourceSet a = randomSet(i);
+            ImmutableResourceSet b = randomSet(i);
+            ImmutableResourceSet c = randomSet(i);
+
+            assertEquals(a.intersection(b).intersection(c), a.intersection(b.intersection(c)));
+        }
+    }
+
+    @Test
+    public void intersection_is_commutative() {
+        for (int i = 0; i < RANDOM_SIZE; ++i) {
+            ImmutableResourceSet a = randomSet(i);
+            ImmutableResourceSet b = randomSet(i);
+
+            assertEquals(a.intersection(b), b.intersection(a));
+        }
+    }
+
+    @Test
+    public void union_and_intersection_are_distributive() {
+        for (int i = 0; i < RANDOM_SIZE; ++i) {
+            ImmutableResourceSet a = randomSet(i);
+            ImmutableResourceSet b = randomSet(i);
+            ImmutableResourceSet c = randomSet(i);
+
+            assertEquals(a.union(b.intersection(c)), (a.union(b)).intersection(a.union(c)));
+            assertEquals(a.intersection(b.union(c)), (a.intersection(b)).union(a.intersection(c)));
+        }
+    }
+
+    @Test
+    public void identity_laws() {
+        for (int i = 0; i < RANDOM_SIZE; ++i) {
+            ImmutableResourceSet a = randomSet(i);
+
+            assertEquals(a, a.union(empty()));
+            assertEquals(a, a.intersection(universal()));
+        }
+    }
+
+    @Test
+    public void complement_laws() {
+        for (int i = 0; i < RANDOM_SIZE; ++i) {
+            ImmutableResourceSet a = randomSet(i);
+
+            assertEquals(universal(), a.union(a.complement()));
+            assertEquals(empty(), a.intersection(a.complement()));
+        }
+    }
+
+    // Proposition 9 of https://www.umsl.edu/~siegelj/SetTheoryandTopology/The_algebra_of_sets.html
+    @Test
+    public void difference_laws() {
+        for (int i = 0; i < RANDOM_SIZE; ++i) {
+            ImmutableResourceSet a = randomSet(i);
+            ImmutableResourceSet b = randomSet(i);
+            ImmutableResourceSet c = randomSet(i);
+
+            assertEquals(c.difference(a.intersection(b)), (c.difference(a)).union(c.difference(b)));
+            assertEquals(c.difference(a.union(b)), (c.difference(a)).intersection(c.difference(b)));
+            assertEquals(c.difference(b.difference(a)), (a.intersection(c)).union(c.difference(b)));
+        }
+
+    }
+
+    private ImmutableResourceSet randomSet(int size) {
+        Random random = new Random();
+        ImmutableResourceSet result = empty();
+        for (int i = 0; i < random.nextInt(size + 1); ++i) {
+            IpResourceType type = IpResourceType.values()[random.nextInt(IpResourceType.values().length)];
+            BigInteger start = BigInteger.valueOf(random.nextInt(Integer.MAX_VALUE - Integer.MAX_VALUE / 256 - 1));
+            BigInteger end = start.add(BigInteger.valueOf(random.nextInt(Integer.MAX_VALUE / 256))).add(BigInteger.ONE);
+            IpResourceRange range = IpResourceRange.range(type.fromBigInteger(start), type.fromBigInteger(end));
+            result = result.add(range);
+        }
+        return result;
+    }
+
+    @Test
+    public void randomized_testing() {
+        ImmutableResourceSet subject = empty();
+        List<IpResourceRange> ranges = new ArrayList<>();
+        Random random = new Random();
+        for (int i = 0; i < RANDOM_SIZE; ++i) {
+            BigInteger start = BigInteger.valueOf(random.nextInt(Integer.MAX_VALUE - Integer.MAX_VALUE / 256 - 1));
+            BigInteger end = start.add(BigInteger.valueOf(random.nextInt(Integer.MAX_VALUE / 256))).add(BigInteger.ONE);
+            IpResourceRange range = IpResourceRange.range(new Asn(start), new Asn(end));
+            ranges.add(range);
+            subject = subject.add(range);
+        }
+
+        for (IpResourceRange range: ranges) {
+            assertTrue(range + " contained in set", subject.contains(range));
+        }
+
+        Iterator<IpResource> iterator = subject.iterator();
+        IpResource previous = iterator.next();
+        while (iterator.hasNext()) {
+            IpResource next = iterator.next();
+            assertTrue("resources out of order <" + previous + "> not before <" + next + ">", previous.compareTo(next) < 0);
+            assertFalse("no mergeable resource in set", previous.isMergeable(next));
+            previous = next;
+        }
+
+        for (IpResourceRange range: ranges) {
+            subject = subject.remove(range);
+        }
+
+        assertTrue("all resources removed: " + subject, subject.isEmpty());
+    }
+}

--- a/src/test/java/net/ripe/ipresource/ImmutableResourceSetTest.java
+++ b/src/test/java/net/ripe/ipresource/ImmutableResourceSetTest.java
@@ -38,11 +38,13 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Stream;
 
+import static net.ripe.ipresource.ImmutableResourceSet.ALL_PRIVATE_USE_RESOURCES;
 import static net.ripe.ipresource.ImmutableResourceSet.empty;
 import static net.ripe.ipresource.ImmutableResourceSet.universal;
 import static net.ripe.ipresource.IpResource.parse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class ImmutableResourceSetTest {
@@ -50,6 +52,18 @@ public class ImmutableResourceSetTest {
     public static final int RANDOM_SIZE = 250;
 
     private final Random random = new Random();
+
+    @Test
+    public void builder_can_only_be_used_once() {
+        ImmutableResourceSet.Builder builder = new ImmutableResourceSet.Builder();
+        builder.build();
+
+        assertThrows(IllegalStateException.class, () -> builder.add(IpAddress.parse("10.0.0.1")));
+        assertThrows(IllegalStateException.class, () -> builder.remove(IpAddress.parse("10.0.0.1")));
+        assertThrows(IllegalStateException.class, () -> builder.addAll(ALL_PRIVATE_USE_RESOURCES));
+        assertThrows(IllegalStateException.class, () -> builder.removeAll(ALL_PRIVATE_USE_RESOURCES));
+        assertThrows(IllegalStateException.class, builder::build);
+    }
 
     @Test
     public void containsAllIpv4Resources() {

--- a/src/test/java/net/ripe/ipresource/ImmutableResourceSetTest.java
+++ b/src/test/java/net/ripe/ipresource/ImmutableResourceSetTest.java
@@ -42,10 +42,7 @@ import static net.ripe.ipresource.ImmutableResourceSet.ALL_PRIVATE_USE_RESOURCES
 import static net.ripe.ipresource.ImmutableResourceSet.empty;
 import static net.ripe.ipresource.ImmutableResourceSet.universal;
 import static net.ripe.ipresource.IpResource.parse;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class ImmutableResourceSetTest {
 
@@ -65,6 +62,20 @@ public class ImmutableResourceSetTest {
         assertThrows(IllegalStateException.class, () -> builder.addAll(ALL_PRIVATE_USE_RESOURCES));
         assertThrows(IllegalStateException.class, () -> builder.removeAll(ALL_PRIVATE_USE_RESOURCES));
         assertThrows(IllegalStateException.class, builder::build);
+    }
+
+    @Test
+    public void should_copy_from_IpResourceSet() {
+        assertSame(ImmutableResourceSet.empty(), ImmutableResourceSet.of(IpResourceSet.parse("")));
+        assertEquals("10.0.0.0/8", ImmutableResourceSet.of(IpResourceSet.parse("10.0.0.0/8")).toString());
+        assertEquals("10.0.0.0/8", ImmutableResourceSet.of((Iterable<IpResource>) IpResourceSet.parse("10.0.0.0/8")).toString());
+    }
+
+    @Test
+    public void should_share_from_ImmutableResourceSet() {
+        assertSame(ImmutableResourceSet.empty(), ImmutableResourceSet.of(ImmutableResourceSet.parse("")));
+        ImmutableResourceSet resources = ImmutableResourceSet.parse("10.0.0.0/8");
+        assertSame(resources, ImmutableResourceSet.of(resources));
     }
 
     @Test

--- a/src/test/java/net/ripe/ipresource/IpResourceSetTest.java
+++ b/src/test/java/net/ripe/ipresource/IpResourceSetTest.java
@@ -189,7 +189,7 @@ public class IpResourceSetTest {
 
     @Test
     public void randomized_testing() {
-        List<IpResourceRange> ranges = new ArrayList<IpResourceRange>();
+        List<IpResourceRange> ranges = new ArrayList<>();
         Random random = new Random();
         for (int i = 0; i < 1000; ++i) {
             BigInteger start = BigInteger.valueOf(random.nextInt(Integer.MAX_VALUE - Integer.MAX_VALUE / 256 - 1));


### PR DESCRIPTION
Every type implemented in this library is represented by an immutable value object, except for the `IpResourceSet`. This is inconsistent and makes the library harder to use. The `ImmutableResourceSet` is an immutable version of `IpResourceSet` and more developer friendly, while it should usually perform just as well. The `ImmutableResourceSet.Builder` can be used if many mutation operations are needed before constructing the final `ImmutableResourceSet`.

This makes the `IpResourceSet` mostly obsolete.

The implementation of the `ImmutableResourceSet` is based on the existing `IpResourceSet` so it should match its behavior and performance.