### PR TITLE
Check invalid octet count AFTER counter increase

### DIFF
--- a/src/main/java/net/ripe/ipresource/Ipv4Address.java
+++ b/src/main/java/net/ripe/ipresource/Ipv4Address.java
@@ -85,10 +85,10 @@ public class Ipv4Address extends IpAddress {
             if (Character.isDigit(ch)) {
                 octet = octet * 10 + (ch - '0');
             } else if (ch == '.') {
+                octetCount++;
                 if (octetCount > 4) {
                     throw new IllegalArgumentException("invalid IPv4 address: " + s);
                 }
-                octetCount++;
 
                 value = addOctet(value, octet);
 

--- a/src/test/java/net/ripe/ipresource/Ipv4AddressTest.java
+++ b/src/test/java/net/ripe/ipresource/Ipv4AddressTest.java
@@ -67,6 +67,16 @@ public class Ipv4AddressTest {
         Ipv4Address.parse("13.-40.0.0");
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailOnTooManyOctets() {
+        Ipv4Address.parse("192.0.2.0.0");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailOnTooManyOctetsAndEnabledDefaultMissingOctets() {
+        Ipv4Address.parse("192.0.2.0.0", true);
+    }
+
     @Test
     public void shouldCalculateCommonPrefix() {
         assertEquals(Ipv4Address.parse("127.0.0.0"), Ipv4Address.parse("127.0.0.1").getCommonPrefix(Ipv4Address.parse("127.15.0.0")));


### PR DESCRIPTION
Due to a misplaced counter check, the old `Ipv4Address.parse(String s, boolean defaultMissingOctets)` used to behave as follows when `defaultMissingOctets` was `true`:

- `"192.0.2"` -> Correct; parsed as `192.0.2.0`
- `"192.0.2.0"` -> Correct; parsed as `192.0.2.0`
- `"192.0.2.0.0"` -> **Correct; parsed as `0.0.0.0`**
- `"192.0.2.0.0.0"` -> Incorrect; throws `IllegalArgumentException`

The new code behaves as follows:

- `"192.0.2"` -> Correct; parsed as `192.0.2.0`
- `"192.0.2.0"` -> Correct; parsed as `192.0.2.0`
- `"192.0.2.0.0"` -> **Incorrect; throws `IllegalArgumentException`**
- `"192.0.2.0.0.0"` -> Incorrect; throws `IllegalArgumentException`